### PR TITLE
Update README.md to 2022 for last year's training

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 * RoboJackets Electrical Training
 
-This is the source repository for the 2021 RoboJackets Electrical training program.
+This is the source repository for the 2022 RoboJackets Electrical training program.


### PR DESCRIPTION
This is for making a tag for last year's training and I want the readme to have the right year in it so it's not confusing.